### PR TITLE
fix context_data declaration 'class' -> 'struct'

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -370,7 +370,7 @@ struct Field {
 using F=Field;
 
 namespace details {
-    class context_data;
+    struct context_data;
     SPDLOG_API std::shared_ptr<context_data>& threadlocal_context_head();
 }
 


### PR DESCRIPTION
This only fires when compiling spdlog for **MSVC** with **cl** and main-app with **clang**:

spdlog.lib -> export -> ... **class** spdlog::details::context_data ...
target     <- import <- ... **struct** spdlog::details::context_data ...

lld-link: error: undefined symbol: **class** std::shared_ptr<struct spdlog::details::context_data> __cdecl spdlog::snapshot_context_fields(void)

Many thanks for structured_spdlog branch!
